### PR TITLE
✨ feat(bot): Add support for JavaScript runtimes in yt-dlp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,5 +88,5 @@ LABEL \
 
 USER 10001:10001
 WORKDIR /tmp
-ENV HOME=/tmp LOG_FORMAT=json LOG_LEVEL=info PID_FILE=/tmp/video-dl-bot.pid
+ENV HOME=/tmp LOG_FORMAT=json LOG_LEVEL=info JS_RUNTIMES=node PID_FILE=/tmp/video-dl-bot.pid
 ENTRYPOINT ["/bin/video-dl-bot"]

--- a/README.md
+++ b/README.md
@@ -141,7 +141,6 @@ For more configuration options, see the [Helm chart documentation][artifacthub].
 | `PID_FILE`                 | Path to PID file for healthchecks               | -         |
 
 <!--GENERATED:APP_README-->
-
 ## 💻 Command line interface
 
 ```
@@ -159,13 +158,13 @@ Options:
    --log-format="…"                        Logging format (console/json) (default: console) [$LOG_FORMAT]
    --bot-token="…", -t="…"                 Telegram bot token [$BOT_TOKEN]
    --cookies-file="…", -c="…"              Path to the file with cookies (netscape-formatted) for the bot (optional) [$COOKIES_FILE]
+   --js-runtimes="…"                       JavaScript runtimes for yt-dlp (e.g. 'node', 'node:/path/to/node', 'bun', 'deno', 'quickjs') [$JS_RUNTIMES]
    --max-concurrent-downloads="…", -m="…"  Maximum number of concurrent downloads (default: 5) [$MAX_CONCURRENT_DOWNLOADS]
    --pid-file="…"                          Path to the file where the process ID will be stored [$PID_FILE]
    --healthcheck                           Check the health of the bot (useful for Docker/K8s healthcheck; pid file must be set) and exit
    --help, -h                              Show help
    --version, -v                           Print the version
 ```
-
 <!--/GENERATED:APP_README-->
 
 ## 🍪 Using Cookies for Authentication

--- a/deployments/helm/templates/deployment.yaml
+++ b/deployments/helm/templates/deployment.yaml
@@ -82,6 +82,9 @@ spec:
             {{- if .cookiesFile }}
             - {name: COOKIES_FILE, value: "{{ .cookiesFile }}"}
             {{- end }}
+            {{- if .jsRuntimes }}
+            - {name: JS_RUNTIMES, value: "{{ .jsRuntimes }}"}
+            {{- end }}
             {{- if .log.level }}
             - {name: LOG_LEVEL, value: "{{ .log.level }}"}
             {{- end }}

--- a/deployments/helm/values.schema.json
+++ b/deployments/helm/values.schema.json
@@ -233,6 +233,9 @@
         "cookiesFile": {
           "oneOf": [{"type": "string", "minLength": 1}, {"type": "null"}]
         },
+        "jsRuntimes": {
+          "oneOf": [{"type": "string", "minLength": 1}, {"type": "null"}]
+        },
         "maxConcurrentDownloads": {
           "oneOf": [{"type": "integer", "minimum": 1, "maximum": 100}, {"type": "null"}]
         }

--- a/deployments/helm/values.yaml
+++ b/deployments/helm/values.yaml
@@ -97,6 +97,9 @@ config:
   # -- Path to the file with cookies (netscape-formatted) for the bot (usually, mounted from a secret)
   cookiesFile: null
 
+  # -- External JS Runtimes (https://github.com/yt-dlp/yt-dlp/wiki/EJS)
+  jsRuntimes: null
+
   # -- Maximum number of concurrent downloads
   # @default 5
   maxConcurrentDownloads: null

--- a/internal/bot/bot.go
+++ b/internal/bot/bot.go
@@ -31,6 +31,7 @@ type (
 	// Bot wraps the Telegram bot client.
 	Bot struct {
 		cookiesFile            string // path to the cookies file (if any)
+		jsRuntimes             string // JavaScript runtimes for yt-dlp (e.g., "node", "bun", "deno", "quickjs")
 		maxConcurrentDownloads uint   // maximum number of concurrent downloads allowed
 
 		log    *slog.Logger
@@ -46,6 +47,9 @@ func WithLogger(log *slog.Logger) Option { return func(b *Bot) { b.log = log } }
 
 // WithCookiesFile sets the path to a cookies file, used by yt-dlp for authenticated downloads.
 func WithCookiesFile(path string) Option { return func(b *Bot) { b.cookiesFile = path } }
+
+// WithJSRuntimes configures the JavaScript runtimes for yt-dlp, allowing support for sites that require JS execution.
+func WithJSRuntimes(runtimes string) Option { return func(b *Bot) { b.jsRuntimes = runtimes } }
 
 // WithMaxConcurrentDownloads limits the number of concurrent downloads the bot can handle.
 func WithMaxConcurrentDownloads(n uint) Option {
@@ -201,6 +205,10 @@ func (b *Bot) handleMessages(pCtx context.Context, lim Limiter) tele.HandlerFunc
 
 		if b.cookiesFile != "" {
 			ytDlpOpts = append(ytDlpOpts, ytdlp.WithCookiesFile(b.cookiesFile))
+		}
+
+		if b.jsRuntimes != "" {
+			ytDlpOpts = append(ytDlpOpts, ytdlp.WithJSRuntimes(b.jsRuntimes))
 		}
 
 		// download the video


### PR DESCRIPTION
## Description

Introduced configuration for external JavaScript runtimes to enhance yt-dlp's capability to handle sites requiring JS execution. Updated Dockerfile, Helm templates, and CLI to support the new `JS_RUNTIMES` environment variable, allowing users to specify runtimes like 'node' or 'bun'. Updated documentation to reflect these changes.
