### PR TITLE
⬆️ build(deps): Upgrade Node.js to version 24 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,10 +63,12 @@ RUN set -x \
 # -✂- and this is the final stage -------------------------------------------------------------------------------------
 FROM docker.io/library/python:3.14.5-slim AS runtime
 
-# install nodejs (https://github.com/yt-dlp/yt-dlp/issues/15012)
+# install nodejs 24 (https://github.com/yt-dlp/yt-dlp/issues/15012)
 RUN set -x \
     && apt update \
-    && apt install nodejs -y \
+    && apt install -y curl \
+    && curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
+    && apt install -y nodejs \
     && rm -r /var/lib/apt/lists/*
 
 COPY --from=ffmpeg /bin/ffmpeg /bin/ffprobe /bin/


### PR DESCRIPTION
## Description

The reason: https://github.com/yt-dlp/yt-dlp/releases/tag/2026.06.09

> **yt-dlp 2026.06.09**
> The minimum supported versions of Deno, Node, and Bun have been raised
> The minimum required version of https://github.com/yt-dlp/yt-dlp/issues/16767 is now v2.3.0; supported https://github.com/yt-dlp/yt-dlp/issues/16765 versions are v22 and up
